### PR TITLE
when lineTo called, use M instead of L unless subpath exists

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -558,7 +558,11 @@
      * Adds a line to command
      */
     ctx.prototype.lineTo = function(x, y){
-        this.__addPathCommand(format("L {x} {y}", {x:x, y:y}));
+        if (this.__currentDefaultPath.indexOf('M') > -1) {
+            this.__addPathCommand(format("L {x} {y}", {x:x, y:y}));
+        } else {
+            this.__addPathCommand(format("M {x} {y}", {x:x, y:y}));
+        }
     };
 
     /**


### PR DESCRIPTION
This should fix https://github.com/gliffy/canvas2svg/issues/21