### PR TITLE
call lineTo instead moveTo in ctx.arc, fixes closePath issue and straight line issue

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -832,7 +832,7 @@
             largeArcFlag = diff > Math.PI ? 1 : 0;
         }
 
-        this.moveTo(startX, startY);
+        this.lineTo(startX, startY);
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {rx:radius, ry:radius, xAxisRotation:0, largeArcFlag:largeArcFlag, sweepFlag:sweepFlag, endX:endX, endY:endY}));
 


### PR DESCRIPTION
According to W3C's doc:

The arc(x, y, radius, startAngle, endAngle, anticlockwise) method draws an arc. If the context has any subpaths, then the method must add a straight line from the last point in the subpath to the start point of the arc.

Also, if we use ctx.moveTo inside ctx.arc, it will create a new subpath, which means that when we call closePath, it will draw a straight line to the wrong point.

![2015-06-07 20 37 16](https://cloud.githubusercontent.com/assets/2544489/8032059/d8b3796e-0e05-11e5-9fb6-816d6ac0e3a6.png)

See also: 

- https://github.com/zenozeng/p5.js-svg/issues/62

- http://www.w3.org/TR/2015/WD-2dcontext-20150514/#dom-context-2d-arc
