### PR TITLE
set paint order before stroke and fill to make them behavior like canvas

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -580,6 +580,9 @@
      * Sets the stroke property on the current element
      */
     ctx.prototype.stroke = function(){
+        if(this.__currentElement.nodeName === "path") {
+            this.__currentElement.setAttribute("paint-order", "fill stroke markers");
+        }
         this.__applyCurrentDefaultPath();
         this.__applyStyleToCurrentElement("stroke");
     };
@@ -588,6 +591,9 @@
      * Sets fill properties on the current element
      */
     ctx.prototype.fill = function(){
+        if(this.__currentElement.nodeName === "path") {
+            this.__currentElement.setAttribute("paint-order", "stroke fill markers");
+        }
         this.__applyCurrentDefaultPath();
         this.__applyStyleToCurrentElement("fill");
     };


### PR DESCRIPTION
This should fix https://github.com/gliffy/canvas2svg/issues/23

In canvas, the order of stroke and fill was determined by call of stroke() and fill(),
in SVG, we should use paint-order to simulate it.

See also: https://github.com/zenozeng/p5.js-svg/issues/63