### PR TITLE
Fix drawImage and add new __clearCanvas

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -447,6 +447,10 @@
      */
     ctx.prototype.restore = function(){
         this.__currentElement = this.__groupStack.pop();
+        //Clearing canvas will make the poped group invalid, currentElement is set to the root group node.
+        if (!this.__currentElement) {
+            this.__currentElement = this.__root.childNodes[1];
+        }
         var state = this.__stack.pop();
         this.__applyStyleState(state);
 
@@ -792,7 +796,7 @@
             }
         }
         this.__currentElement = rootGroup;
-        this.__stack = [this.__getStyleState()];
+        //reset __groupStack as all the child group nodes are all removed.
         this.__groupStack = [];
         if (transform) {
             this.__addTransform(transform);

--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -1077,7 +1077,7 @@
             }
 
             svgImage.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href",
-                image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src"));
+                image.nodeName === "CANVAS" ? image.toDataURL() : image.src);
             parent.appendChild(svgImage);
             this.__currentElement = svgImage;
             this.translate(dx, dy);
@@ -1099,7 +1099,7 @@
             img.setAttribute("width", image.width);
             img.setAttribute("height", image.height);
             img.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href",
-                image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src"));
+                image.nodeName === "CANVAS" ? image.toDataURL() : image.src);
             pattern.appendChild(img);
             this.__defs.appendChild(pattern);
         } else if(image instanceof ctx) {
@@ -1108,7 +1108,7 @@
         }
         return new CanvasPattern(pattern, this);
     };
-    
+
     ctx.prototype.setLineDash = function(dashArray) {
         if (dashArray && dashArray.length > 0) {
             this.lineDash = dashArray.join(",");
@@ -1116,7 +1116,7 @@
             this.lineDash = null;
         }
     };
-    
+
     /**
      * Not yet implemented
      */
@@ -1126,7 +1126,7 @@
     ctx.prototype.putImageData = function(){};
     ctx.prototype.globalCompositeOperation = function(){};
     ctx.prototype.setTransform = function(){};
-    
+
     //add options for alternative namespace
     if (typeof window === "object") {
         window.C2S = ctx;

--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -1071,7 +1071,7 @@
 
         parent = this.__closestGroupOrSvg();
         currentElement = this.__currentElement;
-
+        var translateDirective = "translate(" + dx + ", " + dy + ")";
         if(image instanceof ctx) {
             //canvas2svg mock canvas context. In the future we may want to clone nodes instead.
             //also I'm currently ignoring dw, dh, sw, sh, sx, sy for a mock context.
@@ -1085,7 +1085,15 @@
                 }
                 group = svg.childNodes[1];
                 if (group) {
-                    group.setAttribute("transform",["translate(",dx,",",dy,")"].join(""));
+                    //save original transform
+                    var originTransform = group.getAttribute("transform");
+                    var transformDirective;
+                    if (originTransform) {
+                        transformDirective = originTransform+" "+translateDirective;
+                    } else {
+                        transformDirective = translateDirective;
+                    }
+                    group.setAttribute("transform", transformDirective);
                     parent.appendChild(group);
                 }
             }
@@ -1105,9 +1113,9 @@
                 context.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
                 image = canvas;
             }
-            svgImage.setAttribute("transform",["translate(",dx,",",dy,")"].join(""));
+            svgImage.setAttribute("transform", translateDirective);
             svgImage.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href",
-                image.nodeName === "CANVAS" ? image.toDataURL() : image.src);
+                image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src"));
             parent.appendChild(svgImage);
         }
     };
@@ -1126,7 +1134,7 @@
             img.setAttribute("width", image.width);
             img.setAttribute("height", image.height);
             img.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href",
-                image.nodeName === "CANVAS" ? image.toDataURL() : image.src);
+                image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src"));
             pattern.appendChild(img);
             this.__defs.appendChild(pattern);
         } else if(image instanceof ctx) {

--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -1075,13 +1075,10 @@
                 context.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
                 image = canvas;
             }
-
+            svgImage.setAttribute("transform",["translate(",dx,",",dy,")"].join(""));
             svgImage.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href",
                 image.nodeName === "CANVAS" ? image.toDataURL() : image.src);
             parent.appendChild(svgImage);
-            this.__currentElement = svgImage;
-            this.translate(dx, dy);
-            this.__currentElement = currentElement;
         }
     };
 


### PR DESCRIPTION
1.fixed a bug in drawImage(img, x, y) that makes image not in the right position

Bug desc: when I draw an image on a C2S context,  if the image has siblings, context.translate(x,y) will create a new \<g\> node and set \<g\>'s "transform" attribute instead of image itself which makes image not in the right position.

Because in drawImage method, the image node is directly appended to the parent group, we should translate it to (x,y) by setting image's own "transform" attribute directly instead of by c2s context's translate method which may set transform to a new \<g\> node.

2.implements a new private method __clearCanvas which clears all the current graphics on canvas.

In practice, we usually use Canvas.clearRect(0,0, canvas.width, canvas.height) to clear entire canvas that removes all the current graphics. Thus I added this new private method to remove all graphic child nodes from the root <g> node instead of only adding a white rect node in original clearRect method.

This can also prevent adding unnecessary white rect nodes to canvas when it just clears the canvas. The white rect nodes will cover other graphics when we draw several C2S contexts on a parent C2S context.