### PR TITLE
fixed a bug with globalAlpha

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -141,10 +141,16 @@
             apply : "stroke"
         },
         "globalAlpha": {
-            svgAttr : "opacity",
+            svgAttr : "stroke-opacity",
             canvas : 1,
             svg : 1,
-            apply : "fill stroke"
+            apply :  "stroke"
+        },
+        "globalAlpha": {
+            svgAttr : "fill-opacity",
+            canvas : 1,
+            svg : 1,
+            apply : "fill"
         },
         "font":{
             //font converts to multiple svg attributes, there is custom logic for this
@@ -368,10 +374,24 @@
                         regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?\.?\d*)\s*\)/gi;
                         matches = regex.exec(value);
                         this.__currentElement.setAttribute(style.svgAttr, format("rgb({r},{g},{b})", {r:matches[1], g:matches[2], b:matches[3]}));
-                        this.__currentElement.setAttribute(style.svgAttr+"-opacity", matches[4]);
+                        //should take globalAlpha here
+                        var opacity = matches[4];
+                        var globalAlpha = this.globalAlpha;
+                        if (globalAlpha != null) {
+                            opacity *= globalAlpha;
+                        }
+                        this.__currentElement.setAttribute(style.svgAttr+"-opacity", opacity);
                     } else {
+                        if (keys[i] === 'globalAlpha') {
+                            if (this.__currentElement.getAttribute(style.svgAttr)) {
+                                 //fill-opacity or stroke-opacity has already been set by stroke or fill.
+                                continue;
+                            }
+                        }
                         //otherwise only update attribute if right type, and not svg default
                         this.__currentElement.setAttribute(style.svgAttr, value);
+
+
                     }
                 }
             }

--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -141,16 +141,10 @@
             apply : "stroke"
         },
         "globalAlpha": {
-            svgAttr : "stroke-opacity",
+            svgAttr : "opacity",
             canvas : 1,
             svg : 1,
-            apply :  "stroke"
-        },
-        "globalAlpha": {
-            svgAttr : "fill-opacity",
-            canvas : 1,
-            svg : 1,
-            apply : "fill"
+            apply :  "fill stroke"
         },
         "font":{
             //font converts to multiple svg attributes, there is custom logic for this
@@ -382,14 +376,16 @@
                         }
                         this.__currentElement.setAttribute(style.svgAttr+"-opacity", opacity);
                     } else {
+                        var attr = style.svgAttr;
                         if (keys[i] === 'globalAlpha') {
-                            if (this.__currentElement.getAttribute(style.svgAttr)) {
+                            attr = type+'-'+style.svgAttr;
+                            if (this.__currentElement.getAttribute(attr)) {
                                  //fill-opacity or stroke-opacity has already been set by stroke or fill.
                                 continue;
                             }
                         }
                         //otherwise only update attribute if right type, and not svg default
-                        this.__currentElement.setAttribute(style.svgAttr, value);
+                        this.__currentElement.setAttribute(attr, value);
 
 
                     }

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -296,4 +296,40 @@ describe('canvas2svg', function() {
         });
 
     });
+
+    describe("supports globalOpacity", function() {
+        it("set stroke-opacity when stroking and set fill-opacity when filling",function() {
+            var ctx = new C2S();
+            ctx.globalAlpha = 0.5;
+            ctx.moveTo(5,5);
+            ctx.lineTo(15,15);
+            ctx.stroke();
+            var svg = ctx.getSvg();
+            expect(svg.querySelector("path").getAttribute("stroke-opacity")).to.equal('0.5');
+            ctx.globalAlpha = 0.1;
+            ctx.fillStyle = "#000000";
+            ctx.fill();
+            expect(svg.querySelector("path").getAttribute("fill-opacity")).to.equal('0.1');
+            //stroke-opacity stays o.5
+            expect(svg.querySelector("path").getAttribute("stroke-opacity")).to.equal('0.5');
+        });
+
+        it("added into color opacity when stroking or filling with rgba style color. ",function() {
+            var ctx = new C2S();
+            ctx.strokeStyle="rgba(0,0,0,0.8)";
+            ctx.globalAlpha = 0.5;
+            ctx.moveTo(5,5);
+            ctx.lineTo(15,15);
+            ctx.stroke();
+            var svg = ctx.getSvg();
+            expect(svg.querySelector("path").getAttribute("stroke")).to.equal('rgb(0,0,0)');
+            //stroke-opacity should be globalAlpha*(alpha in rgba)
+            expect(svg.querySelector("path").getAttribute("stroke-opacity")).to.equal(''+0.8*0.5);
+            ctx.globalAlpha = 0.6;
+            ctx.fillStyle = "rgba(0,0,0,0.6)";
+            ctx.fill();
+            expect(svg.querySelector("path").getAttribute("fill-opacity")).to.equal(''+0.6*0.6);
+            expect(svg.querySelector("path").getAttribute("stroke-opacity")).to.equal(''+0.8*0.5);
+        });
+    });
 });


### PR DESCRIPTION
Hi,

At first, I would like to thanks for merging my last pull request.

This is another bugfix with globalAlpha.

### Problem:

ctx.fill() and ctx.stroke() can both set element's "opacity" attribute with globalAlpha value, so when we set globalAlpha for multiple times, opacity may be set to a wrong value.

eg:

        //draw a simple line here.
        ctx.moveTo(0,0);
        ctx.lineTo(5,5);

        ctx.globalAlpha = 1;
        //this draws the line, set its opacity to 1 and display.
        ctx.stroke();        

        ctx.globalAlpha = 0;
        //the line's opacity is set to 0 
        //which incorrectly makes the whole line transparent instead of only a transparent fill.
        ctx.fill();

### Fix:

1. when setting "stroke" or "fill", take globalAlpha into consideration.
2. instead of always setting "opacity", set "fill-opacity"  when fill() and "stroke-opacity" when stroke() seperately.