### PR TITLE
Set image 'opacity' attribute in drawImage method

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -1141,6 +1141,7 @@
             svgImage = this.__createElement("image");
             svgImage.setAttribute("width", dw);
             svgImage.setAttribute("height", dh);
+            svgImage.setAttribute("opacity", this.globalAlpha);
             svgImage.setAttribute("preserveAspectRatio", "none");
 
             if (sx || sy || sw !== image.width || sh !== image.height) {


### PR DESCRIPTION
Set opacity attribute of images. Right now, the opacity is always set to 1, try the following:
```js
ctx.globalAlpha = 0.5;
var img = new Image();
img.src = "https://www.w3schools.com/tags/img_the_scream.jpg"

ctx.drawImage(img, 0, 0);
```