### PR TITLE
fix(__applyStyleToCurrentElement): prevent null values

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -362,7 +362,7 @@
         for (i = 0; i < keys.length; i++) {
             style = STYLES[keys[i]];
             value = this[keys[i]];
-            if (style.apply) {
+            if (style.apply && value) {
                 //is this a gradient or pattern?
                 if (value instanceof CanvasPattern) {
                     //pattern


### PR DESCRIPTION
if value coerces to false, svg conversion crashes. Had this issue with converting chart.js charts from canvas to svg. After prevent null values it worked as intended. Just want to contribute that little fix. thanks for the great work with that library !!!