### PR TITLE
Fix Text decoration accepted values

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -902,14 +902,14 @@
      * @private
      */
     ctx.prototype.__parseFont = function () {
-        var regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\'\"\sa-z0-9]+?)\s*$/i;
+        var regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(underline|overline|line-through|blink))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\'\"\sa-z0-9]+?)\s*$/i;
         var fontPart = regex.exec( this.font );
         var data = {
             style : fontPart[1] || 'normal',
             size : fontPart[4] || '10px',
             family : fontPart[6] || 'sans-serif',
             weight: fontPart[3] || 'normal',
-            decoration : fontPart[2] || 'normal',
+            decoration : fontPart[2] || 'none',
             href : null
         };
 


### PR DESCRIPTION
Before this fix, Small-caps was the accepted value. After the fix only the following values are accepted: underline, overline, line-through, blink. In case no value is specified, the default(none) is used.

Fixes #90.