### PR TITLE
Improves regex handling for REGEX

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -902,7 +902,7 @@
      * @private
      */
     ctx.prototype.__parseFont = function () {
-        var regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\'\"\sa-z0-9]+?)\s*$/i;
+        var regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-_,\"\sa-z0-9]+?)\s*$/i;
         var fontPart = regex.exec( this.font );
         var data = {
             style : fontPart[1] || 'normal',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "canvas2svg",
-  "version": "1.0.19",
+  "name": "@lumel/canvas2svg",
+  "version": "1.0.20",
   "description": "canvas2svg",
   "main": "canvas2svg.js",
   "homepage": "http://gliffy.github.io/canvas2svg/",


### PR DESCRIPTION
Hello, this PR improves the regex matching for `parseFont`, adds support for underscore

**Current behaviour**
![Screenshot 2023-11-17 at 1 05 37 PM](https://github.com/gliffy/canvas2svg/assets/4598631/ac065ce9-6d7f-44bf-951d-94d1e9e0f8e1)

**New behaviour with updated Regex**
![Screenshot 2023-11-17 at 1 04 40 PM](https://github.com/gliffy/canvas2svg/assets/4598631/5d122186-e482-4282-a68f-d779254dd6c0)
